### PR TITLE
ローディングのカラー更新 / Riveアニメーションの埋め込みコードを追加

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -1308,7 +1308,7 @@
           <svg class="progress-ring" viewBox="0 0 240 240">
             <circle
               class="progress-ring__circle"
-              stroke="var(--figma-color-bg-component)"
+              stroke="var(--figma-color-bg)"
               stroke-width="10"
               fill="transparent"
               r="52"
@@ -1316,6 +1316,9 @@
               cy="120"
             />
           </svg>
+          <!-- Riveアニメーションの埋め込みコードを追加 -->
+          <!-- <iframe style="border: none" width="240" height="240" src="https://rive.app/s/glK6npsX0UmOVp3TR09idQ/embed" allowfullscreen></iframe> -->
+          <!-- ローディングテキストは必要に応じて表示 -->
           <span class="progress-text">Applying fonts...</span>
         </div>
       </div>


### PR DESCRIPTION
表題の通り、修正を行なった


ただ、RiveのアニメーションはDMMのCSP（Content Security Policy）の設定で、エラーが出たので設定はできなかった。
もし設定で表示できるようなった場合、公開するPluginには「"Pencil Icon" by guidorosso, used under CC BY / Made with Rive」を記載すること

